### PR TITLE
Add mailcatcher into the dance.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :development, :test do
   gem "better_errors"
   gem "dotenv-rails"
   gem "faker"
+  gem "mailcatcher"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
+    daemons (1.2.4)
     database_cleaner (1.4.1)
     debug_inspector (0.0.2)
     devise (3.5.6)
@@ -96,6 +97,7 @@ GEM
       dotenv (= 2.1.1)
       railties (>= 4.0, < 5.1)
     erubis (2.7.0)
+    eventmachine (1.0.9.1)
     execjs (2.6.0)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
@@ -132,6 +134,14 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    mailcatcher (0.6.5)
+      eventmachine (= 1.0.9.1)
+      mail (~> 2.3)
+      rack (~> 1.5)
+      sinatra (~> 1.2)
+      skinny (~> 0.2.3)
+      sqlite3 (~> 1.3)
+      thin (~> 1.5.0)
     method_source (0.8.2)
     mime-types (3.0)
       mime-types-data (~> 3.2015)
@@ -171,6 +181,8 @@ GEM
     rack (1.6.4)
     rack-mini-profiler (0.9.9.2)
       rack (>= 1.2.0)
+    rack-protection (1.5.3)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.6)
@@ -244,6 +256,13 @@ GEM
       websocket (~> 1.0)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
+    sinatra (1.4.8)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    skinny (0.2.4)
+      eventmachine (~> 1.0.0)
+      thin (>= 1.5, < 1.7)
     slop (3.6.0)
     spring (1.7.1)
     sprockets (3.6.0)
@@ -253,6 +272,11 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sqlite3 (1.3.13)
+    thin (1.5.1)
+      daemons (>= 1.0.9)
+      eventmachine (>= 0.12.6)
+      rack (>= 1.0.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.2)
@@ -294,6 +318,7 @@ DEPENDENCIES
   jquery-infinite-pages
   jquery-rails
   kaminari
+  mailcatcher
   omniauth-github
   pg (~> 0.15)
   pry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,4 +315,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.12.5
+   1.14.6

--- a/Procfile.development
+++ b/Procfile.development
@@ -1,0 +1,2 @@
+web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
+mailcatcher: mailcatcher -f

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,15 +40,12 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.default_url_options = { host: "devsdeck.com" }
+  config.action_mailer.default_url_options = {
+    host: "localhost:#{ENV["PORT"] || "3000"}"
+  }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address: "smtp-relay.sendinblue.com",
-    port: 587,
-    domain: "devsdeck.com",
-    authentication: "plain",
-    enable_starttls_auto: true,
-    user_name: ENV["SENDINBLUE_USER"],
-    password: ENV["SENDINBLUE_PASS"]
+    address: "localhost",
+    port: 1025
   }
 end


### PR DESCRIPTION
# What is this good for❓ 

Devsdeck sends emails related to user password recovering, and stuff.

The [mailcatcher](https://mailcatcher.me/) is an application that allows us to see, in a very nice way, all the emails that are sent to its smpt server.

## How it is done ❓ 

This PR add the development env config to use it, and also the _Procfile.development_ with the _Mailcatcher_ usage example.